### PR TITLE
Add mock TLS header for GET

### DIFF
--- a/services/hydra.js
+++ b/services/hydra.js
@@ -14,7 +14,15 @@ if (process.env.MOCK_TLS_TERMINATION) {
 function get(flow, challenge) {
   const url = new URL('/oauth2/auth/requests/' + flow, hydraUrl)
   url.search = querystring.stringify({[flow + '_challenge']: challenge})
-  return fetch(url.toString())
+  return fetch(
+    url.toString(),
+    {
+      method: 'GET',
+      headers: {
+        ...mockTlsTermination
+      }
+    }
+    )
     .then(function (res) {
       if (res.status < 200 || res.status > 302) {
         // This will handle any errors that aren't network related (network related errors are handled automatically)


### PR DESCRIPTION
## Related issue

@aeneasr I have hit an issue similar to that described in #31 and I think I know what the problem is (and have a proposed fix). My hydra server is listening for http connections on a local subnet. The public port (4444) is proxied behind apache, which adds the https forwarding header.

I'm running the login and consent node on the server on the Docker network talking directly over the local subnet to hydra's admin port (4445). I've enabled `MOCK_TLS_TERMINATION` since my hydra is configured to deny http requests without `X-Forwarded-Proto: https`. However, I get the error from the login and consent client, which I traced to:
```
dcc_oauth-consent.1.44y0u1lg5ik5@docker-desktop    | An error occurred while making a HTTP request:  { error: 'error',
dcc_oauth-consent.1.44y0u1lg5ik5@docker-desktop    |   error_description: 'The error is unrecognizable.',
dcc_oauth-consent.1.44y0u1lg5ik5@docker-desktop    |   status_code: 500,
dcc_oauth-consent.1.44y0u1lg5ik5@docker-desktop    |   error_debug: 'can not serve request over insecure http',
dcc_oauth-consent.1.44y0u1lg5ik5@docker-desktop    |   request_id: '' }
```

## Proposed changes

The problem seems to be caused by the the code in hydra.js only adding `X-Forwarded-Proto: https` to the post helper and not the get helper function. This patch adds `X-Forwarded-Proto: https` to the get helper and fixes my issue. I can now get a token through the consent flow (tested using the Insomnia REST client).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Hopefully, this is a straightforward change. I didn't modify the docs, as they already say to add `MOCK_TLS_TERMINATION` for this use case.