### PR TITLE
fix: Allow configurable BASE_URL + error view bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,11 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
+    "@types/url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/csurf": "^1.9.36",
     "@types/express": "^4.17.7",
     "@types/morgan": "^1.9.1",
+    "@types/url-join": "^4.0.0",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",

--- a/src/routes/consent.ts
+++ b/src/routes/consent.ts
@@ -65,6 +65,7 @@ router.get('/', csrfProtection, (req, res, next) => {
         requested_scope: body.requestedScope,
         user: body.subject,
         client: body.client,
+        action: url.resolve(process.env.BASE_URL || '', '/consent'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/src/routes/consent.ts
+++ b/src/routes/consent.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import url from 'url'
+import urljoin from 'url-join'
 import csrf from 'csurf'
 import {hydraAdmin} from '../config'
 
@@ -65,7 +66,7 @@ router.get('/', csrfProtection, (req, res, next) => {
         requested_scope: body.requestedScope,
         user: body.subject,
         client: body.client,
-        action: url.resolve(process.env.BASE_URL || '', '/consent'),
+        action: urljoin(process.env.BASE_URL || '', '/consent'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -41,6 +41,7 @@ router.get('/', csrfProtection, (req, res, next) => {
       res.render('login', {
         csrfToken: req.csrfToken(),
         challenge: challenge,
+        action: url.resolve(process.env.BASE_URL || '', '/login'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import url from 'url'
+import urljoin from 'url-join'
 import csrf from 'csurf'
 import {hydraAdmin} from '../config'
 
@@ -41,7 +42,7 @@ router.get('/', csrfProtection, (req, res, next) => {
       res.render('login', {
         csrfToken: req.csrfToken(),
         challenge: challenge,
-        action: url.resolve(process.env.BASE_URL || '', '/login'),
+        action: urljoin(process.env.BASE_URL || '', '/login'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/src/routes/logout.ts
+++ b/src/routes/logout.ts
@@ -27,6 +27,7 @@ router.get('/', csrfProtection, (req, res, next) => {
       res.render('logout', {
         csrfToken: req.csrfToken(),
         challenge: challenge,
+        action: url.resolve(process.env.BASE_URL || '', '/logout'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/src/routes/logout.ts
+++ b/src/routes/logout.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import url from 'url'
+import urljoin from 'url-join'
 import csrf from 'csurf'
 import {hydraAdmin} from '../config'
 
@@ -27,7 +28,7 @@ router.get('/', csrfProtection, (req, res, next) => {
       res.render('logout', {
         csrfToken: req.csrfToken(),
         challenge: challenge,
-        action: url.resolve(process.env.BASE_URL || '', '/logout'),
+        action: urljoin(process.env.BASE_URL || '', '/logout'),
       });
     })
     // This will handle any error that happens when making HTTP calls to hydra

--- a/views/consent.pug
+++ b/views/consent.pug
@@ -2,7 +2,7 @@ extends layout
 
 block content
     h1 An application requests access to your data!
-    form(action="",method="POST")
+    form(action=action,method="POST")
         input(type="hidden",name="challenge",value=challenge)
         input(type="hidden",name="_csrf",value=csrfToken)
 

--- a/views/error.pug
+++ b/views/error.pug
@@ -2,4 +2,6 @@ extends layout
 
 block content
   h1= message
-  pre #{error.stack}
+  
+  if error
+    pre #{error.stack}

--- a/views/login.pug
+++ b/views/login.pug
@@ -5,7 +5,7 @@ block content
     if error
         p.
             #{error}
-    form(action="/login",method="POST")
+    form(action=action,method="POST")
         input(type="hidden",name="_csrf",value=csrfToken)
         input(type="hidden",name="challenge",value=challenge)
         table(style="")

--- a/views/logout.pug
+++ b/views/logout.pug
@@ -5,7 +5,7 @@ block content
     if error
         p.
             #{error}
-    form(action="/logout",method="POST")
+    form(action=action,method="POST")
         input(type="hidden",name="_csrf",value=csrfToken)
         input(type="hidden",name="challenge",value=challenge)
         input(type="submit",id="accept",value="Yes")


### PR DESCRIPTION
## Related issue

None.

## Proposed changes

This PR introduces the opportunity of setting the environment variable `BASE_URL` which will be used as prefix in the forms. This change allows developers to deploy the application under different paths via reverse proxy + rewrite.

This PR also fixes a broken error view when "error" is undefined.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

An additional PR might be useful for the Helm chart `example-idp` - this would add the appropriate documentation to point out how to set the BASE_URL variable.