### PR TITLE
fix: do not run as root in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:14.15-alpine3.12
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+RUN adduser -S ory -D -u 10000 -s /bin/nologin
+
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 RUN npm ci --silent; exit 0
@@ -10,6 +12,8 @@ RUN npm ci --silent; exit 0
 COPY . /usr/src/app
 
 RUN npm run build
+
+USER 10000
 
 ENTRYPOINT npm run serve
 


### PR DESCRIPTION
## Related issue

None

## Proposed changes

It is quite common and advised to restrict running privileged containers. This change will allow running this application in Kubernetes where Pod Security Policy disallows running privileged containers (root user).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

