### PR TITLE
feat: Allow login with multiple users for simulating multi-user applications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Please head over to the
 [ORY Hydra 5 Minute Tutorial](https://www.ory.sh/docs/hydra/5min-tutorial) to
 see how this works.
 
+### Allowing login from multiple email addresses
+
+If desired, instead of logging in with email foo@bar.com and password foobar,
+you may set the `ALLOWED_LOGIN_DOMAIN` environment variable to any domain.
+This will cause the application to accept logins from any address from that domain
+with password foobar. For example, if you set it to `domain.com`, this
+application will accept logins from any email address ending in `@domain.com`
+with password foobar.
+
 ## FAQ
 
 ### TLS Termination

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,4 +17,8 @@ const configuration = new Configuration({
 
 const hydraAdmin = new V0alpha2Api(configuration)
 
-export { hydraAdmin }
+const options: { allowedLoginDomain?: string } = {
+  allowedLoginDomain: process.env.ALLOWED_LOGIN_DOMAIN,
+}
+
+export { hydraAdmin, options }


### PR DESCRIPTION
Set the environment variable `ALLOWED_LOGIN_DOMAIN` to a domain (e.g. "domain.com") to allow any e-mail address from that domain to log in using the password "foobar".

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
